### PR TITLE
getFunctionAppURL moved to the SDK

### DIFF
--- a/src/getFunctionAppURL.ts
+++ b/src/getFunctionAppURL.ts
@@ -1,0 +1,32 @@
+import { HostKeys, WebSiteManagementClient } from "@azure/arm-appservice";
+
+export async function getFunctionAppURL(client: WebSiteManagementClient, functionRg: string, functionAppName: string): Promise<string | undefined> {
+    try {
+
+        // TODO: We should think about if we need to support slots
+        // DOCS: https://docs.microsoft.com/en-us/rest/api/appservice/web-apps/list-host-name-bindings
+
+        let functionAppURL = client.webApps.listHostNameBindings(functionRg, functionAppName);
+        
+        // i'm only getting the first result; can discuss if this is the right strategy
+        let functionAppURLJSON:any = JSON.parse(JSON.stringify(await functionAppURL.next()));
+
+        if (functionAppURLJSON["value"]["name"]){
+
+            // remove the function name and '/' from the result; ex: in('functionName/functionName.azurewebsites.net') -> out('functionName.azurewebsites.net')
+            let hostName:string = functionAppURLJSON["value"]["name"].slice(functionAppName.length + 1,);
+            
+            return "https://" + hostName + "/api";
+
+        } else {
+
+            return "error parsing response for site name: " + JSON.stringify(functionAppURLJSON);
+
+        }
+    } catch (error) {
+
+        console.log(error);
+        
+    }
+
+}

--- a/src/getFunctionKey.ts
+++ b/src/getFunctionKey.ts
@@ -3,7 +3,7 @@ import { HostKeys, WebSiteManagementClient } from "@azure/arm-appservice";
 export async function getFunctionKey(client: WebSiteManagementClient, functionRg: string, functionAppName: string, apimName: string) {
     try {
 
-        //https://docs.microsoft.com/en-us/rest/api/appservice/web-apps/list-host-keys
+        // DOCS: https://docs.microsoft.com/en-us/rest/api/appservice/web-apps/list-host-keys
         let functionKey = client.webApps.listHostKeys(functionRg, functionAppName);
         
         //convert the object to a JSON object


### PR DESCRIPTION
- queries listHostNameBindings()
- only returns the first hostname in the response (can discuss if that is the right strategy)
- converts response to JSON object and returns site name
- removes the <functionName>/ prefix 
- returns to main() with https (prefix) & /api (suffix)