### PR TITLE
ExecutionContext and cleanup of input variables

### DIFF
--- a/import_function.ts
+++ b/import_function.ts
@@ -8,15 +8,18 @@ import { WebSiteManagementClient } from "@azure/arm-appservice";
 
 const executionContext = ExecutionContext.create();
 
-const functionRg: string = "Split";
-const functionAppName: string = "SplitTestFunction";
+const functionRg: string = "apim-backend-functionapp";
+const functionAppName: string = "testFunction";
 const displayName: string = "Test API 3";
 const apiName: string = "test3";
 let apiUrlSuffix: string = "";
-const apimRg: string = "lithographtestfunction";
-const apimName: string = "lithograph-test";
+
+const apimRg: string = "apim-functionapp";
+const apimName: string = "function-test";
+
 let apiProduct: string = "";
 const apiVersion = "2021-01-01-preview";
+
 
 let accessToken: string = "Bearer ";
 let auth = {headers: {'Authorization': accessToken, 'Content-Type': 'application/json'}}
@@ -205,7 +208,7 @@ async function main() {
     // Get list of individual functions within function app
     console.log('Getting Functions...')
     const functions = await getFunctions(client, functionRg, functionAppName);
-    console.log(functions)
+    //console.log(functions)
     // console.log(functions.map((x: { properties: { name: any; }; }) => x.properties.name));
 
     // Get key for functions

--- a/import_function.ts
+++ b/import_function.ts
@@ -203,7 +203,8 @@ function addPolicy(apimRg: string, apimName: string, apiName: string, operationN
 
 async function main() {
 
-    let client = new WebSiteManagementClient(credential, subscriptionId);
+    const client = new WebSiteManagementClient(credential, subscriptionId);
+
     // TODO: use credential with SDK
     // Kevin H - Temporary to have the existing implementation successfully run
     accessToken = (await credential.getToken("https://management.azure.com"))?.token!;

--- a/import_function.ts
+++ b/import_function.ts
@@ -1,11 +1,12 @@
 import axios from 'axios'
-import { CredentialProvider } from './src/credentialProvider';
+import ExecutionContext from './src/executionContext';
 import { getFunctions } from './src/getFunctions';
 import { getFunctionKey } from './src/getFunctionKey';
 
 import { WebSiteManagementClient } from "@azure/arm-appservice";
 
-const subscriptionId = "811ac24a-7a5f-41a7-acff-8dd138042333";
+const executionContext = ExecutionContext.create();
+
 const functionRg: string = "Split";
 const functionAppName: string = "SplitTestFunction";
 const displayName: string = "Test API 3";
@@ -19,11 +20,8 @@ let accessToken: string = "Bearer ";
 let auth = {headers: {'Authorization': accessToken, 'Content-Type': 'application/json'}}
 
 
-const baseUrl: string = "https://management.azure.com/subscriptions/811ac24a-7a5f-41a7-acff-8dd138042333/";
+const baseUrl: string = `https://management.azure.com/subscriptions/${executionContext.getSubscriptionId()}/`;
 // functions = "resourceGroups/Split/providers/Microsoft.Web/sites/SplitTestFunction?api-version=2016-08-01";
-
-const credentialProvider = new CredentialProvider();
-const credential = credentialProvider.get();
 
 async function getFunctionApp(functionRg: string, functionAppName: string): Promise<string | undefined> {
     const metadataUrl = "resourceGroups/" + functionRg + "/providers/Microsoft.Web/sites/" + functionAppName + "?api-version=2016-08-01";
@@ -203,7 +201,8 @@ function addPolicy(apimRg: string, apimName: string, apiName: string, operationN
 
 async function main() {
 
-    const client = new WebSiteManagementClient(credential, subscriptionId);
+    const credential = executionContext.getCredential();
+    const client = new WebSiteManagementClient(credential, executionContext.getSubscriptionId());
 
     // TODO: use credential with SDK
     // Kevin H - Temporary to have the existing implementation successfully run

--- a/import_function.ts
+++ b/import_function.ts
@@ -21,11 +21,7 @@ const apiVersion = "2021-01-01-preview";
 let accessToken: string = "Bearer ";
 let auth = {headers: {'Authorization': accessToken, 'Content-Type': 'application/json'}}
 
-const baseUrl: string = "https://management.azure.com/subscriptions/" + subscriptionId + "/";
-// functions = "resourceGroups/Split/providers/Microsoft.Web/sites/SplitTestFunction?api-version=2016-08-01";
-
-const credentialProvider = new CredentialProvider();
-const credential = credentialProvider.get();
+const baseUrl: string = `https://management.azure.com/subscriptions/${executionContext.getSubscriptionId()}/`;
 
 function createApi(apimRg: string, apimName: string, apiName: string, displayName: string) {
 

--- a/import_function.ts
+++ b/import_function.ts
@@ -9,13 +9,13 @@ import { WebSiteManagementClient } from "@azure/arm-appservice";
 const executionContext = ExecutionContext.create();
 
 const functionRg: string = "apim-backend-functionapp";
-const functionAppName: string = "testFunction";
+const functionAppName: string = "testFunction-";
 const displayName: string = "Test API 3";
 const apiName: string = "test3";
 let apiUrlSuffix: string = "";
 
 const apimRg: string = "apim-functionapp";
-const apimName: string = "function-test";
+const apimName: string = "apim-function-test";
 
 let apiProduct: string = "";
 const apiVersion = "2021-01-01-preview";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,30 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@actions/core": "^1.6.0",
         "@azure/arm-appservice": "^11.0.0",
         "@azure/identity": "^2.0.1",
         "axios": "^0.24.0"
       },
       "devDependencies": {
+        "dotenv": "^14.3.2",
         "typescript": "^4.5.5"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "dependencies": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dependencies": {
+        "tunnel": "0.0.6"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -352,6 +370,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -625,6 +652,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
@@ -648,6 +683,22 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "requires": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "requires": {
+        "tunnel": "0.0.6"
+      }
+    },
     "@azure/abort-controller": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.4.tgz",
@@ -913,6 +964,12 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "dotenv": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-14.3.2.tgz",
+      "integrity": "sha512-vwEppIphpFdvaMCaHfCEv9IgwcxMljMw2TnAQBB4VWPvzXQLTb82jwmdOKzlEVUL3gNFT4l4TPKO+Bn+sqcrVQ==",
+      "dev": true
+    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1112,6 +1169,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typescript": {
       "version": "4.5.5",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "### Problem The current APIM experience is very UI-driven, requiring user interaction through the Azure Portal to import and update APIs, even when hosted in native Azure services such as Functions. If Functions are being used as part of a production solution, this manual process acts as a blocker, slowing developer momentum.",
   "scripts": {
+    "dev": "tsc && node -r dotenv/config ./dist/import_function.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -16,11 +17,13 @@
   },
   "homepage": "https://github.com/wdfox/DevOpsWithAPIM#readme",
   "dependencies": {
+    "@actions/core": "^1.6.0",
     "@azure/arm-appservice": "^11.0.0",
     "@azure/identity": "^2.0.1",
     "axios": "^0.24.0"
   },
   "devDependencies": {
+    "dotenv": "^14.3.2",
     "typescript": "^4.5.5"
   }
 }

--- a/src/credentialProvider.ts
+++ b/src/credentialProvider.ts
@@ -16,15 +16,6 @@ export class CredentialProvider {
         this.options = options;
     }
 
-    private isClientCredential(): boolean {
-        if (this.options) {
-            return !!this.options.tenantId 
-                && !!this.options.clientSecret 
-                && !!this.options.clientId;
-        }
-        return false;
-    }
-    
     public get(): TokenCredential {
         if (this.isClientCredential()) {
             const o = this.options as CredentialProviderOptions;
@@ -35,5 +26,18 @@ export class CredentialProvider {
               );
         }
         return new DefaultAzureCredential();
+    }
+
+    private isClientCredential(): boolean {
+        if (this.options) {
+            return !this.isEmpty(this.options.tenantId) 
+                && !this.isEmpty(this.options.clientSecret)
+                && !this.isEmpty(this.options.clientId);
+        }
+        return false;
+    }
+    
+    private isEmpty(value: string | undefined): boolean {
+        return (!value || value.length === 0 );
     }
 }

--- a/src/executionContext.ts
+++ b/src/executionContext.ts
@@ -1,10 +1,9 @@
 import * as core from '@actions/core'
 import { TokenCredential } from "@azure/identity";
-import { CredentialProvider, CredentialProviderOptions } from './credentialProvider'
-
+import { CredentialProvider } from './credentialProvider'
 
 /**
- * @summary factory for authentication with default credentials (that includes CLI) or with an app registration’s client Id and secret.
+ * @summary Execution context of the action to hold all the inputs to execute operations
  */
  export default class ExecutionContext {
      private credential?: TokenCredential;

--- a/src/executionContext.ts
+++ b/src/executionContext.ts
@@ -1,0 +1,46 @@
+import * as core from '@actions/core'
+import { TokenCredential } from "@azure/identity";
+import { CredentialProvider, CredentialProviderOptions } from './credentialProvider'
+
+
+/**
+ * @summary factory for authentication with default credentials (that includes CLI) or with an app registration’s client Id and secret.
+ */
+ export default class ExecutionContext {
+     private credential?: TokenCredential;
+
+     constructor(private credentialProvider: CredentialProvider, private subscriptionId: string) {
+     }
+
+     public getCredential(): TokenCredential {
+         return this.credential ?? (this.credential = this.credentialProvider.get());
+     }
+
+     public getSubscriptionId(): string {
+         return this.subscriptionId;
+     }
+
+     public static create(): ExecutionContext {
+        const credentialProvider = new CredentialProvider({
+            clientId: core.getInput('client-id', { required: false }),
+            clientSecret: core.getInput('client-secret', { required: false }),
+            tenantId: core.getInput('tenant-id', { required: false })
+        })
+
+        let subscriptionId = ExecutionContext.getSubscriptionId();
+
+        return new ExecutionContext(credentialProvider, subscriptionId);
+     }
+
+     private static getSubscriptionId(): string {
+        const inputSubscriptionId = core.getInput('');
+         
+        const subscriptionId = inputSubscriptionId.length === 0 ? process.env.SUBSCRIPTION_ID : inputSubscriptionId;
+
+        if (!subscriptionId) {
+            throw new Error("Azure Subscription ID not found.")
+        }
+
+        return subscriptionId;
+     }
+ }


### PR DESCRIPTION
#### Changes:
- removing hard coded subscription id
- GH actions inputs for values
- pulled in core for actions
- "execution context" type that will allow us to track all inputs from the GitHub action onto a single object, including:
   - the security context (service principal)
   - the subscription id
   - function and apim instance info

